### PR TITLE
Man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ The default API `chat/completions` provides:
   ```
   You may want to add this file to a directory in `$PATH`. 
 
-  Also install the openai manual page, e.g.:
-  ```pandoc -s -f markdown -t man README.md > /usr/local/man/man1/openai.1
+  Also install the manual page, e.g.:
+  ```bash
+  pandoc -s -f markdown -t man README.md > /usr/local/man/man1/openai.1
   ```
   <details>
   <summary>Further reading: curl's killer feature</summary>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The default API `chat/completions` provides:
   chmod +x openai
   ```
   You may want to add this file to a directory in `$PATH`. 
+
+  Also install the openai manual page, e.g.:
+  ```pandoc -s -f markdown -t man README.md > /usr/local/man/man1/openai.1
+  ```
   <details>
   <summary>Further reading: curl's killer feature</summary>
   <a href="https://daniel.haxx.se/blog/2020/09/10/store-the-curl-output-over-there/"><code>-OJ</code> is a killer feature</a>


### PR DESCRIPTION
This adds instructions in the markdown README.md file on how to create and install an openai manual page.  pandoc installation is required.  I assume you don't want to add a manual page file to the source tree that would be a duplicate of README.md.