### PR TITLE
Prevent trailing newline in dry_run output

### DIFF
--- a/openai
+++ b/openai
@@ -208,7 +208,7 @@ openai_chat_completions() {
 		update_conversation user "$prompt"
 		update_conversation "$role" "$text"
 	}
-	echo
+	[ "$dry_run" -eq 0 ] && echo
 }
 
 # shellcheck disable=SC2120


### PR DESCRIPTION
In -n/dry_run output, the dry_run output goes to stderr, but a newline is generated on stdout.  This patch prevents the stdout output in this mode.